### PR TITLE
Fix by updating Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,9 @@ TypeScript React "react-testing-library" "user-event" Multiple Select Demo
 
 Try "user-event" in tests to simulate user selected options in a multiple select.
 
-But not all work as expected:
-1. check `option.selected` is work as expected
-2. `onChange` callback doesn't have expected values
-
 ```
 npm install
 npm run test
 ```
 
-It will fail and have error messages in console.
+It should succeed.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "16.9.4",
     "css-loader": "3.2.0",
     "html-webpack-plugin": "3.2.0",
-    "jest": "24.9.0",
+    "jest": "26.0.1",
     "karma": "4.4.1",
     "source-map-loader": "0.2.4",
     "style-loader": "1.0.0",

--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -16,6 +16,7 @@ export default function MultiSelect({onSelectedValuesChange}: Props) {
 
   return <select multiple data-testid="select-multiple"
                  onChange={onSelectOptions} style={{width: '100px'}}>
+    <option data-testid="val0" value="" disabled>0</option>
     <option data-testid="val1" value="1">1</option>
     <option data-testid="val2" value="2">2</option>
     <option data-testid="val3" value="3">3</option>


### PR DESCRIPTION
I have fixed the failing tests by updating Jest with `npm install jest@latest`. It appears this was just a bug with an older bundled version of JSDOM, not `user-event`.